### PR TITLE
Truly correctness

### DIFF
--- a/superfly-common/src/main/java/com/payneteasy/superfly/common/singleton/SingletonHolder.java
+++ b/superfly-common/src/main/java/com/payneteasy/superfly/common/singleton/SingletonHolder.java
@@ -8,7 +8,7 @@ package com.payneteasy.superfly.common.singleton;
  * @param <T>
  */
 public abstract class SingletonHolder<T> {
-    private T instance;
+    private volatile T instance;
 
     /**
      * Obtains a singleton instance held by this object.


### PR DESCRIPTION
I found one unsafe initialization during quick walkthrough on project.
Instance should be volatile to set hb edge between createInstance() and first read instance
In absence of volatile you can see not null but not fully initialized object.

For more info see
https://shipilev.net/blog/2014/safe-public-construction/